### PR TITLE
Support for Country Code and National Number

### DIFF
--- a/android/src/main/java/com/julienvignali/phone_number/PhoneNumberPlugin.java
+++ b/android/src/main/java/com/julienvignali/phone_number/PhoneNumberPlugin.java
@@ -86,6 +86,7 @@ public class PhoneNumberPlugin implements MethodCallHandler {
                         put("international", util.format(phoneNumber, PhoneNumberUtil.PhoneNumberFormat.INTERNATIONAL));
                         put("national", util.format(phoneNumber, PhoneNumberUtil.PhoneNumberFormat.NATIONAL));
                         put("country_code", String.valueOf(phoneNumber.getCountryCode()));
+                        put("national_number", String.valueOf(phoneNumber.getNationalNumber()));
                     }};
                     result.success(res);
                 } else {

--- a/android/src/main/java/com/julienvignali/phone_number/PhoneNumberPlugin.java
+++ b/android/src/main/java/com/julienvignali/phone_number/PhoneNumberPlugin.java
@@ -85,6 +85,7 @@ public class PhoneNumberPlugin implements MethodCallHandler {
                         put("e164", util.format(phoneNumber, PhoneNumberUtil.PhoneNumberFormat.E164));
                         put("international", util.format(phoneNumber, PhoneNumberUtil.PhoneNumberFormat.INTERNATIONAL));
                         put("national", util.format(phoneNumber, PhoneNumberUtil.PhoneNumberFormat.NATIONAL));
+                        put("country_code", String.valueOf(phoneNumber.getCountryCode()));
                     }};
                     result.success(res);
                 } else {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -32,6 +32,7 @@ class _MyAppState extends State<MyApp> {
       international: ${parsed['international']}
       national: ${parsed['national']}
       country code: ${parsed['country_code']}
+      national number: ${parsed['national_number']}
       """;
 
       final formatted = await PhoneNumber.format('499881517', 'BR');

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -31,6 +31,7 @@ class _MyAppState extends State<MyApp> {
       e164: ${parsed['e164']} 
       international: ${parsed['international']}
       national: ${parsed['national']}
+      country code: ${parsed['country_code']}
       """;
 
       final formatted = await PhoneNumber.format('499881517', 'BR');

--- a/ios/Classes/SwiftPhoneNumberPlugin.swift
+++ b/ios/Classes/SwiftPhoneNumberPlugin.swift
@@ -79,7 +79,8 @@ public class SwiftPhoneNumberPlugin: NSObject, FlutterPlugin {
                 "e164": kit.format(phoneNumber, toType: .e164),
                 "international": kit.format(phoneNumber, toType: .international, withPrefix: true),
                 "national": kit.format(phoneNumber, toType: .national),
-                "country_code": String(phoneNumber.countryCode)
+                "country_code": String(phoneNumber.countryCode),
+                "national_number": String(phoneNumber.nationalNumber)
             ]
 
             result(res)

--- a/ios/Classes/SwiftPhoneNumberPlugin.swift
+++ b/ios/Classes/SwiftPhoneNumberPlugin.swift
@@ -78,7 +78,8 @@ public class SwiftPhoneNumberPlugin: NSObject, FlutterPlugin {
                 "type": phoneNumber.type.toString(),
                 "e164": kit.format(phoneNumber, toType: .e164),
                 "international": kit.format(phoneNumber, toType: .international, withPrefix: true),
-                "national": kit.format(phoneNumber, toType: .national)
+                "national": kit.format(phoneNumber, toType: .national),
+                "country_code": String(phoneNumber.countryCode)
             ]
 
             result(res)


### PR DESCRIPTION
closes #6 

Example usage:
```
final parsed = await PhoneNumber.parse("+79991234567");
platformVersion = """
country code: ${parsed['country_code']}
national number: ${parsed['national_number']}
""";
```

In case of `+79991234567` country code is `7` and national number is `9991234567`