### PR TITLE
Add Namespace to Support Gradle 8.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    namespace "flutter.plugins.phone_number"
+    namespace "com.julienvignali.phone_number"
 
     compileSdkVersion 33
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,6 +22,8 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    namespace "flutter.plugins.phone_number"
+
     compileSdkVersion 33
 
     compileOptions {


### PR DESCRIPTION
**Context**:
Recent updates in Gradle 8.0 have introduced a requirement for specifying a namespace in the `build.gradle` file of Android projects. This change impacts the build process of the `phone_number` Flutter package, leading to build failures with the following error message:

```
FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring project ':phone_number'.
> Could not create an instance of type com.android.build.api.variant.impl.LibraryVariantBuilderImpl.
   > Namespace not specified. Please specify a namespace in the module's build.gradle file like so:

     android {
         namespace 'com.example.namespace'
     }

     If the package attribute is specified in the source AndroidManifest.xml, it can be migrated automatically to the namespace value in the build.gradle file using the AGP Upgrade Assistant; please refer to https://developer.android.com/studio/build/agp-upgrade-assistant for more information.
...
```

**Changes**:
This pull request addresses the build failure by adding a namespace to the `build.gradle` file of the `phone_number` package. The namespace is aligned with the existing package structure to ensure consistency and avoid any potential conflicts.

**Implementation**:
- Added the `namespace` declaration in the `android` block of the `build.gradle` file.
- Ensured the namespace is reflective of the package's existing structure by mirroring the package name used in the AndroidManifest.xml.

**Impact**:
- This change is necessary for compatibility with Gradle 8.0 and newer versions.
- It ensures that developers using the `phone_number` package can build their Flutter applications without encountering the specified build error.

I look forward to your review and suggestions. This update aims to maintain the compatibility and functionality of the `phone_number` package with the latest Gradle version.